### PR TITLE
Support multipart/form-data requests

### DIFF
--- a/kubeless.js
+++ b/kubeless.js
@@ -30,7 +30,6 @@ module.exports = function kubeless(options){
   } = options;
 
   const originalEnvironment = Object.assign({}, process.env);
-  const bodySizeLimit = Number(process.env.REQ_MB_LIMIT || '1');
 
   const app = express();
   app.use(morgan('combined'));

--- a/kubeless.js
+++ b/kubeless.js
@@ -30,15 +30,17 @@ module.exports = function kubeless(options){
   } = options;
 
   const originalEnvironment = Object.assign({}, process.env);
+  const bodySizeLimit = Number(process.env.REQ_MB_LIMIT || '1');
 
   const app = express();
   app.use(morgan('combined'));
   const bodParserOptions = {
-    type: req => !req.is('multipart/*')
+    type: req => !req.is('multipart/*'),
+    limit: `${bodySizeLimit}mb`,
   };
   app.use(bodyParser.raw(bodParserOptions));
-  app.use(bodyParser.json());
-  app.use(bodyParser.urlencoded({extended: true}));
+  app.use(bodyParser.json({ limit: `${bodySizeLimit}mb` }));
+  app.use(bodyParser.urlencoded({ limit: `${bodySizeLimit}mb`, extended: true }));
 
   const timeout = Number(FUNC_TIMEOUT || '180');
   const funcPort = Number(FUNC_PORT || '3000');

--- a/kubeless.js
+++ b/kubeless.js
@@ -34,7 +34,7 @@ module.exports = function kubeless(options){
   const app = express();
   app.use(morgan('combined'));
   const bodParserOptions = {
-    type: req => !req.is('multipart/form-data')
+    type: req => !req.is('multipart/*')
   };
   app.use(bodyParser.raw(bodParserOptions));
   app.use(bodyParser.json());
@@ -80,7 +80,7 @@ module.exports = function kubeless(options){
 
     try {
       let data = req.body;
-      if (!req.is('multipart/form-data') && req.body.length > 0) {
+      if (!req.is('multipart/*') && req.body.length > 0) {
         if (req.get('content-type') === 'application/json') {
           data = JSON.parse(req.body.toString('utf-8'))
         } else {

--- a/kubeless.js
+++ b/kubeless.js
@@ -34,9 +34,11 @@ module.exports = function kubeless(options){
   const app = express();
   app.use(morgan('combined'));
   const bodParserOptions = {
-    type: '*/*'
+    type: req => !req.is('multipart/form-data')
   };
   app.use(bodyParser.raw(bodParserOptions));
+  app.use(bodyParser.json());
+  app.use(bodyParser.urlencoded({extended: true}));
 
   const timeout = Number(FUNC_TIMEOUT || '180');
   const funcPort = Number(FUNC_PORT || '3000');
@@ -78,7 +80,7 @@ module.exports = function kubeless(options){
 
     try {
       let data = req.body;
-      if (req.body.length > 0) {
+      if (!req.is('multipart/form-data') && req.body.length > 0) {
         if (req.get('content-type') === 'application/json') {
           data = JSON.parse(req.body.toString('utf-8'))
         } else {


### PR DESCRIPTION
In order to support multipart/form-data requests to upload files we need to change he behavior of the raw parser. Also, event.data should not convert the body to string in these cases.