### PR TITLE
Find handlers whose route has a leading slash 

### DIFF
--- a/kubeless.js
+++ b/kubeless.js
@@ -157,8 +157,8 @@ module.exports = function kubeless(options){
       res.header('Access-Control-Allow-Headers', req.headers['access-control-request-headers']);
       res.end();
     } else {
-      // don't include the leading `/`
-      const targetRoute = routeToFunctionSpec(req.path.substr(1));
+      // try finding function without leading `/`, and then retry with the leading `/`
+      const targetRoute = routeToFunctionSpec(req.path.substr(1)) || routeToFunctionSpec(req.path);
 
       // request for a route we don't support, e.g. favicon.ico
       if (!targetRoute) {


### PR DESCRIPTION
# Why do we need this?

Serverless allows both routes without leading slash and with leading slash.  This offline package can cover the former one, but not the latter one. (And we use the latter one!)

# How did I implement it?

First, we try finding a function whose route does not have a leading slash. If we find one, use it. Otherwise, we try finding a function whose route has a leading slash. Thus this patch does not break older versions.