### PR TITLE
Fix deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,10 +42,12 @@ class KubelessOfflinePlugin {
               + '(e.g. "--port 3000" or "-p 3000")',
             required: false,
             shortcut: 'p',
+            type: 'string',
           },
           httpsProtocol: {
             usage: 'To enable HTTPS, specify directory (relative to your cwd, typically your project dir) for both key.pem and server.crt files.',
             shortcut: 'H',
+            type: 'string',
           },
         },
       },


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - KubelessOfflinePlugin for "port", "httpsProtocol"
```